### PR TITLE
Changed the method of fetching the session cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,5 @@ poetry.toml
 
 
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm,flask
+
+cookie


### PR DESCRIPTION
* Before, it was from an environment variable, but somehow changing it did not solve the issue. So, I instead now store the value in a file and it is read every time someone access the results page. So, we no longer need to restart the gunicorn service.
* Added an exception when the session cookie value is empty.